### PR TITLE
CFLAGS to allow build on Illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ endif
 
 override CFLAGS +=-Wall -Iinclude -std=c99
 
+ifeq ($(shell uname),SunOS)
+  override CFLAGS +=-D__EXTENSIONS__ -D_XPG6 -D__XOPEN_OR_POSIX
+endif
+
 ifeq ($(DEBUG),1)
   override CFLAGS +=-ggdb -DDEBUG
 endif


### PR DESCRIPTION
This quick change and a simple forkpty() implementation per the discussion at https://github.com/neovim/neovim/pull/2049 should allow Neovim to work on Illumos and other modern Solaris and OpenSolaris-based distributions, likely SmartOS too.
