### PR TITLE
Replace // comments with /* */ comments.

### DIFF
--- a/include/vterm.h
+++ b/include/vterm.h
@@ -72,29 +72,29 @@ typedef union {
 
 typedef enum {
   /* VTERM_ATTR_NONE = 0 */
-  VTERM_ATTR_BOLD = 1,   // bool:   1, 22
-  VTERM_ATTR_UNDERLINE,  // number: 4, 21, 24
-  VTERM_ATTR_ITALIC,     // bool:   3, 23
-  VTERM_ATTR_BLINK,      // bool:   5, 25
-  VTERM_ATTR_REVERSE,    // bool:   7, 27
-  VTERM_ATTR_STRIKE,     // bool:   9, 29
-  VTERM_ATTR_FONT,       // number: 10-19
-  VTERM_ATTR_FOREGROUND, // color:  30-39 90-97
-  VTERM_ATTR_BACKGROUND, // color:  40-49 100-107
+  VTERM_ATTR_BOLD = 1,   /* bool:   1, 22 */
+  VTERM_ATTR_UNDERLINE,  /* number: 4, 21, 24 */
+  VTERM_ATTR_ITALIC,     /* bool:   3, 23 */
+  VTERM_ATTR_BLINK,      /* bool:   5, 25 */
+  VTERM_ATTR_REVERSE,    /* bool:   7, 27 */
+  VTERM_ATTR_STRIKE,     /* bool:   9, 29 */
+  VTERM_ATTR_FONT,       /* number: 10-19 */
+  VTERM_ATTR_FOREGROUND, /* color:  30-39 90-97 */
+  VTERM_ATTR_BACKGROUND, /* color:  40-49 100-107 */
 
   VTERM_N_ATTRS
 } VTermAttr;
 
 typedef enum {
   /* VTERM_PROP_NONE = 0 */
-  VTERM_PROP_CURSORVISIBLE = 1, // bool
-  VTERM_PROP_CURSORBLINK,       // bool
-  VTERM_PROP_ALTSCREEN,         // bool
-  VTERM_PROP_TITLE,             // string
-  VTERM_PROP_ICONNAME,          // string
-  VTERM_PROP_REVERSE,           // bool
-  VTERM_PROP_CURSORSHAPE,       // number
-  VTERM_PROP_MOUSE,             // number
+  VTERM_PROP_CURSORVISIBLE = 1, /* bool */
+  VTERM_PROP_CURSORBLINK,       /* bool */
+  VTERM_PROP_ALTSCREEN,         /* bool */
+  VTERM_PROP_TITLE,             /* string */
+  VTERM_PROP_ICONNAME,          /* string */
+  VTERM_PROP_REVERSE,           /* bool */
+  VTERM_PROP_CURSORSHAPE,       /* number */
+  VTERM_PROP_MOUSE,             /* number */
 
   VTERM_N_PROPS
 } VTermProp;
@@ -163,9 +163,10 @@ void vterm_keyboard_end_paste(VTerm *vt);
 void vterm_mouse_move(VTerm *vt, int row, int col, VTermModifier mod);
 void vterm_mouse_button(VTerm *vt, int button, bool pressed, VTermModifier mod);
 
-// ------------
-// Parser layer
-// ------------
+/* ------------
+ * Parser layer
+ * ------------
+ */
 
 /* Flag to indicate non-final subparameters in a single CSI parameter.
  * Consider
@@ -201,9 +202,10 @@ typedef struct {
 void  vterm_parser_set_callbacks(VTerm *vt, const VTermParserCallbacks *callbacks, void *user);
 void *vterm_parser_get_cbdata(VTerm *vt);
 
-// -----------
-// State layer
-// -----------
+/* -----------
+ * State layer
+ * -----------
+ */
 
 typedef struct {
   int (*putglyph)(VTermGlyphInfo *info, VTermPos pos, void *user);
@@ -224,7 +226,7 @@ VTermState *vterm_obtain_state(VTerm *vt);
 void  vterm_state_set_callbacks(VTermState *state, const VTermStateCallbacks *callbacks, void *user);
 void *vterm_state_get_cbdata(VTermState *state);
 
-// Only invokes control, csi, osc, dcs
+/* Only invokes control, csi, osc, dcs */
 void  vterm_state_set_unrecognised_fallbacks(VTermState *state, const VTermParserCallbacks *fallbacks, void *user);
 void *vterm_state_get_unrecognised_fbdata(VTermState *state);
 
@@ -241,9 +243,10 @@ void vterm_state_focus_in(VTermState *state);
 void vterm_state_focus_out(VTermState *state);
 const VTermLineInfo *vterm_state_get_lineinfo(const VTermState *state, int row);
 
-// ------------
-// Screen layer
-// ------------
+/* ------------
+ * Screen layer
+ * ------------
+ */
 
 typedef struct {
     unsigned int bold      : 1;
@@ -281,7 +284,7 @@ VTermScreen *vterm_obtain_screen(VTerm *vt);
 void  vterm_screen_set_callbacks(VTermScreen *screen, const VTermScreenCallbacks *callbacks, void *user);
 void *vterm_screen_get_cbdata(VTermScreen *screen);
 
-// Only invokes control, csi, osc, dcs
+/* Only invokes control, csi, osc, dcs */
 void  vterm_screen_set_unrecognised_fallbacks(VTermScreen *screen, const VTermParserCallbacks *fallbacks, void *user);
 void *vterm_screen_get_unrecognised_fbdata(VTermScreen *screen);
 
@@ -325,9 +328,10 @@ int vterm_screen_get_cell(const VTermScreen *screen, VTermPos pos, VTermScreenCe
 
 int vterm_screen_is_eol(const VTermScreen *screen, VTermPos pos);
 
-// ---------
-// Utilities
-// ---------
+/* ---------
+ * Utilities
+ * ---------
+ */
 
 VTermValueType vterm_get_attr_type(VTermAttr attr);
 VTermValueType vterm_get_prop_type(VTermProp prop);

--- a/include/vterm_keycodes.h
+++ b/include/vterm_keycodes.h
@@ -7,7 +7,7 @@ typedef enum {
   VTERM_MOD_ALT   = 0x02,
   VTERM_MOD_CTRL  = 0x04,
 
-  VTERM_ALL_MODS_MASK = 0x07 
+  VTERM_ALL_MODS_MASK = 0x07
 } VTermModifier;
 
 typedef enum {
@@ -52,7 +52,7 @@ typedef enum {
   VTERM_KEY_KP_ENTER,
   VTERM_KEY_KP_EQUAL,
 
-  VTERM_KEY_MAX, // Must be last
+  VTERM_KEY_MAX, /* Must be last */
   VTERM_N_KEYS = VTERM_KEY_MAX
 } VTermKey;
 

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -7,11 +7,11 @@
 #endif
 
 struct UTF8DecoderData {
-  // number of bytes remaining in this codepoint
+  /* number of bytes remaining in this codepoint */
   int bytes_remaining;
 
-  // number of bytes total in this codepoint once it's finished
-  // (for detecting overlongs)
+  /* number of bytes total in this codepoint once it's finished
+   * (for detecting overlongs) */
   int bytes_total;
 
   int this_cp;
@@ -42,7 +42,7 @@ static void decode_utf8(VTermEncoding *enc, void *data_,
     printf(" pos=%zd c=%02x rem=%d\n", *pos, c, data->bytes_remaining);
 #endif
 
-    if(c < 0x20) // C0
+    if(c < 0x20) /* C0 */
       return;
 
     else if(c >= 0x20 && c < 0x7f) {
@@ -56,7 +56,7 @@ static void decode_utf8(VTermEncoding *enc, void *data_,
       data->bytes_remaining = 0;
     }
 
-    else if(c == 0x7f) // DEL
+    else if(c == 0x7f) /* DEL */
       return;
 
     else if(c >= 0x80 && c < 0xc0) {
@@ -73,7 +73,7 @@ static void decode_utf8(VTermEncoding *enc, void *data_,
 #ifdef DEBUG_PRINT_UTF8
         printf(" UTF-8 raw char U+%04x bytelen=%d ", data->this_cp, data->bytes_total);
 #endif
-        // Check for overlong sequences
+        /* Check for overlong sequences */
         switch(data->bytes_total) {
         case 2:
           if(data->this_cp <  0x0080) data->this_cp = UNICODE_INVALID;
@@ -91,7 +91,7 @@ static void decode_utf8(VTermEncoding *enc, void *data_,
           if(data->this_cp < 0x4000000) data->this_cp = UNICODE_INVALID;
           break;
         }
-        // Now look for plain invalid ones
+        /* Now look for plain invalid ones */
         if((data->this_cp >= 0xD800 && data->this_cp <= 0xDFFF) ||
            data->this_cp == 0xFFFE ||
            data->this_cp == 0xFFFF)

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -13,7 +13,7 @@ void vterm_keyboard_unichar(VTerm *vt, uint32_t c, VTermModifier mod)
     mod &= ~VTERM_MOD_SHIFT;
 
   if(mod == 0) {
-    // Normal text - ignore just shift
+    /* Normal text - ignore just shift */
     char str[6];
     int seqlen = fill_utf8(c, str);
     vterm_push_output_bytes(vt, str, seqlen);
@@ -68,61 +68,61 @@ typedef struct {
 } keycodes_s;
 
 static keycodes_s keycodes[] = {
-  { KEYCODE_NONE }, // NONE
+  { KEYCODE_NONE }, /* NONE */
 
-  { KEYCODE_ENTER,   '\r'   }, // ENTER
-  { KEYCODE_TAB,     '\t'   }, // TAB
-  { KEYCODE_LITERAL, '\x7f' }, // BACKSPACE == ASCII DEL
-  { KEYCODE_LITERAL, '\x1b' }, // ESCAPE
+  { KEYCODE_ENTER,   '\r'   }, /* ENTER */
+  { KEYCODE_TAB,     '\t'   }, /* TAB */
+  { KEYCODE_LITERAL, '\x7f' }, /* BACKSPACE == ASCII DEL */
+  { KEYCODE_LITERAL, '\x1b' }, /* ESCAPE */
 
-  { KEYCODE_CSI_CURSOR, 'A' }, // UP
-  { KEYCODE_CSI_CURSOR, 'B' }, // DOWN
-  { KEYCODE_CSI_CURSOR, 'D' }, // LEFT
-  { KEYCODE_CSI_CURSOR, 'C' }, // RIGHT
+  { KEYCODE_CSI_CURSOR, 'A' }, /* UP */
+  { KEYCODE_CSI_CURSOR, 'B' }, /* DOWN */
+  { KEYCODE_CSI_CURSOR, 'D' }, /* LEFT */
+  { KEYCODE_CSI_CURSOR, 'C' }, /* RIGHT */
 
-  { KEYCODE_CSINUM, '~', 2 },  // INS
-  { KEYCODE_CSINUM, '~', 3 },  // DEL
-  { KEYCODE_CSI_CURSOR, 'H' }, // HOME
-  { KEYCODE_CSI_CURSOR, 'F' }, // END
-  { KEYCODE_CSINUM, '~', 5 },  // PAGEUP
-  { KEYCODE_CSINUM, '~', 6 },  // PAGEDOWN
+  { KEYCODE_CSINUM, '~', 2 },  /* INS */
+  { KEYCODE_CSINUM, '~', 3 },  /* DEL */
+  { KEYCODE_CSI_CURSOR, 'H' }, /* HOME */
+  { KEYCODE_CSI_CURSOR, 'F' }, /* END */
+  { KEYCODE_CSINUM, '~', 5 },  /* PAGEUP */
+  { KEYCODE_CSINUM, '~', 6 },  /* PAGEDOWN */
 };
 
 static keycodes_s keycodes_fn[] = {
-  { KEYCODE_NONE },            // F0 - shouldn't happen
-  { KEYCODE_CSI_CURSOR, 'P' }, // F1
-  { KEYCODE_CSI_CURSOR, 'Q' }, // F2
-  { KEYCODE_CSI_CURSOR, 'R' }, // F3
-  { KEYCODE_CSI_CURSOR, 'S' }, // F4
-  { KEYCODE_CSINUM, '~', 15 }, // F5
-  { KEYCODE_CSINUM, '~', 17 }, // F6
-  { KEYCODE_CSINUM, '~', 18 }, // F7
-  { KEYCODE_CSINUM, '~', 19 }, // F8
-  { KEYCODE_CSINUM, '~', 20 }, // F9
-  { KEYCODE_CSINUM, '~', 21 }, // F10
-  { KEYCODE_CSINUM, '~', 23 }, // F11
-  { KEYCODE_CSINUM, '~', 24 }, // F12
+  { KEYCODE_NONE },            /* F0 - shouldn't happen */
+  { KEYCODE_CSI_CURSOR, 'P' }, /* F1 */
+  { KEYCODE_CSI_CURSOR, 'Q' }, /* F2 */
+  { KEYCODE_CSI_CURSOR, 'R' }, /* F3 */
+  { KEYCODE_CSI_CURSOR, 'S' }, /* F4 */
+  { KEYCODE_CSINUM, '~', 15 }, /* F5 */
+  { KEYCODE_CSINUM, '~', 17 }, /* F6 */
+  { KEYCODE_CSINUM, '~', 18 }, /* F7 */
+  { KEYCODE_CSINUM, '~', 19 }, /* F8 */
+  { KEYCODE_CSINUM, '~', 20 }, /* F9 */
+  { KEYCODE_CSINUM, '~', 21 }, /* F10 */
+  { KEYCODE_CSINUM, '~', 23 }, /* F11 */
+  { KEYCODE_CSINUM, '~', 24 }, /* F12 */
 };
 
 static keycodes_s keycodes_kp[] = {
-  { KEYCODE_KEYPAD, '0', 'p' }, // KP_0
-  { KEYCODE_KEYPAD, '1', 'q' }, // KP_1
-  { KEYCODE_KEYPAD, '2', 'r' }, // KP_2
-  { KEYCODE_KEYPAD, '3', 's' }, // KP_3
-  { KEYCODE_KEYPAD, '4', 't' }, // KP_4
-  { KEYCODE_KEYPAD, '5', 'u' }, // KP_5
-  { KEYCODE_KEYPAD, '6', 'v' }, // KP_6
-  { KEYCODE_KEYPAD, '7', 'w' }, // KP_7
-  { KEYCODE_KEYPAD, '8', 'x' }, // KP_8
-  { KEYCODE_KEYPAD, '9', 'y' }, // KP_9
-  { KEYCODE_KEYPAD, '*', 'j' }, // KP_MULT
-  { KEYCODE_KEYPAD, '+', 'k' }, // KP_PLUS
-  { KEYCODE_KEYPAD, ',', 'l' }, // KP_COMMA
-  { KEYCODE_KEYPAD, '-', 'm' }, // KP_MINUS
-  { KEYCODE_KEYPAD, '.', 'n' }, // KP_PERIOD
-  { KEYCODE_KEYPAD, '/', 'o' }, // KP_DIVIDE
-  { KEYCODE_KEYPAD, '\n', 'M' }, // KP_ENTER
-  { KEYCODE_KEYPAD, '=', 'X' }, // KP_EQUAL
+  { KEYCODE_KEYPAD, '0', 'p' }, /* KP_0 */
+  { KEYCODE_KEYPAD, '1', 'q' }, /* KP_1 */
+  { KEYCODE_KEYPAD, '2', 'r' }, /* KP_2 */
+  { KEYCODE_KEYPAD, '3', 's' }, /* KP_3 */
+  { KEYCODE_KEYPAD, '4', 't' }, /* KP_4 */
+  { KEYCODE_KEYPAD, '5', 'u' }, /* KP_5 */
+  { KEYCODE_KEYPAD, '6', 'v' }, /* KP_6 */
+  { KEYCODE_KEYPAD, '7', 'w' }, /* KP_7 */
+  { KEYCODE_KEYPAD, '8', 'x' }, /* KP_8 */
+  { KEYCODE_KEYPAD, '9', 'y' }, /* KP_9 */
+  { KEYCODE_KEYPAD, '*', 'j' }, /* KP_MULT */
+  { KEYCODE_KEYPAD, '+', 'k' }, /* KP_PLUS */
+  { KEYCODE_KEYPAD, ',', 'l' }, /* KP_COMMA */
+  { KEYCODE_KEYPAD, '-', 'm' }, /* KP_MINUS */
+  { KEYCODE_KEYPAD, '.', 'n' }, /* KP_PERIOD */
+  { KEYCODE_KEYPAD, '/', 'o' }, /* KP_DIVIDE */
+  { KEYCODE_KEYPAD, '\n', 'M' }, /* KP_ENTER */
+  { KEYCODE_KEYPAD, '=', 'X' }, /* KP_EQUAL */
 };
 
 void vterm_keyboard_key(VTerm *vt, VTermKey key, VTermModifier mod)

--- a/src/parser.c
+++ b/src/parser.c
@@ -148,18 +148,18 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
   for( ; pos < len; pos++) {
     unsigned char c = bytes[pos];
 
-    if(c == 0x00 || c == 0x7f) { // NUL, DEL
+    if(c == 0x00 || c == 0x7f) { /* NUL, DEL */
       if(vt->parser.state >= STRING) {
         more_string(vt, string_start, bytes + pos - string_start);
         string_start = bytes + pos + 1;
       }
       continue;
     }
-    if(c == 0x18 || c == 0x1a) { // CAN, SUB
+    if(c == 0x18 || c == 0x1a) { /* CAN, SUB */
       ENTER_NORMAL_STATE();
       continue;
     }
-    else if(c == 0x1b) { // ESC
+    else if(c == 0x1b) { /* ESC */
       vt->parser.intermedlen = 0;
       if(vt->parser.state == STRING)
         vt->parser.state = ESC_IN_STRING;
@@ -167,11 +167,11 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
         ENTER_STATE(ESC);
       continue;
     }
-    else if(c == 0x07 &&  // BEL, can stand for ST in OSC or DCS state
+    else if(c == 0x07 &&  /* BEL, can stand for ST in OSC or DCS state */
             vt->parser.state == STRING) {
-      // fallthrough
+      /* fallthrough */
     }
-    else if(c < 0x20) { // other C0
+    else if(c < 0x20) { /* other C0 */
       if(vt->parser.state >= STRING)
         more_string(vt, string_start, bytes + pos - string_start);
       do_control(vt, c);
@@ -179,30 +179,30 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
         string_start = bytes + pos + 1;
       continue;
     }
-    // else fallthrough
+    /* else fallthrough */
 
     switch(vt->parser.state) {
     case ESC_IN_STRING:
-      if(c == 0x5c) { // ST
+      if(c == 0x5c) { /* ST */
         vt->parser.state = STRING;
         done_string(vt, string_start, bytes + pos - string_start - 1);
         ENTER_NORMAL_STATE();
         break;
       }
       vt->parser.state = ESC;
-      // else fallthrough
+      /* else fallthrough */
 
     case ESC:
       switch(c) {
-      case 0x50: // DCS
+      case 0x50: /* DCS */
         start_string(vt, VTERM_PARSER_DCS);
         ENTER_STRING_STATE();
         break;
-      case 0x5b: // CSI
+      case 0x5b: /* CSI */
         vt->parser.csi_leaderlen = 0;
         ENTER_STATE(CSI_LEADER);
         break;
-      case 0x5d: // OSC
+      case 0x5d: /* OSC */
         start_string(vt, VTERM_PARSER_OSC);
         ENTER_STRING_STATE();
         break;
@@ -292,14 +292,14 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
     case NORMAL:
       if(c >= 0x80 && c < 0xa0 && !vt->mode.utf8) {
         switch(c) {
-        case 0x90: // DCS
+        case 0x90: /* DCS */
           start_string(vt, VTERM_PARSER_DCS);
           ENTER_STRING_STATE();
           break;
-        case 0x9b: // CSI
+        case 0x9b: /* CSI */
           ENTER_STATE(CSI_LEADER);
           break;
-        case 0x9d: // OSC
+        case 0x9d: /* OSC */
           start_string(vt, VTERM_PARSER_OSC);
           ENTER_STRING_STATE();
           break;
@@ -319,7 +319,7 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
           eaten = 1;
         }
 
-        pos += (eaten - 1); // we'll ++ it again in a moment
+        pos += (eaten - 1); /* we'll ++ it again in a moment */
       }
       break;
     }

--- a/src/pen.c
+++ b/src/pen.c
@@ -4,24 +4,24 @@
 
 static const VTermColor ansi_colors[] = {
   /* R    G    B */
-  {   0,   0,   0 }, // black
-  { 224,   0,   0 }, // red
-  {   0, 224,   0 }, // green
-  { 224, 224,   0 }, // yellow
-  {   0,   0, 224 }, // blue
-  { 224,   0, 224 }, // magenta
-  {   0, 224, 224 }, // cyan
-  { 224, 224, 224 }, // white == light grey
+  {   0,   0,   0 }, /* black */
+  { 224,   0,   0 }, /* red */
+  {   0, 224,   0 }, /* green */
+  { 224, 224,   0 }, /* yellow */
+  {   0,   0, 224 }, /* blue */
+  { 224,   0, 224 }, /* magenta */
+  {   0, 224, 224 }, /* cyan */
+  { 224, 224, 224 }, /* white == light grey */
 
-  // high intensity
-  { 128, 128, 128 }, // black
-  { 255,  64,  64 }, // red
-  {  64, 255,  64 }, // green
-  { 255, 255,  64 }, // yellow
-  {  64,  64, 255 }, // blue
-  { 255,  64, 255 }, // magenta
-  {  64, 255, 255 }, // cyan
-  { 255, 255, 255 }, // white for real
+  /* high intensity */
+  { 128, 128, 128 }, /* black */
+  { 255,  64,  64 }, /* red */
+  {  64, 255,  64 }, /* green */
+  { 255, 255,  64 }, /* yellow */
+  {  64,  64, 255 }, /* blue */
+  { 255,  64, 255 }, /* magenta */
+  {  64, 255, 255 }, /* cyan */
+  { 255, 255, 255 }, /* white for real */
 };
 
 static int ramp6[] = {
@@ -46,11 +46,11 @@ static bool lookup_colour_ansi(const VTermState *state, long index, VTermColor *
 static bool lookup_colour_palette(const VTermState *state, long index, VTermColor *col)
 {
   if(index >= 0 && index < 16) {
-    // Normal 8 colours or high intensity - parse as palette 0
+    /* Normal 8 colours or high intensity - parse as palette 0 */
     return lookup_colour_ansi(state, index, col);
   }
   else if(index >= 16 && index < 232) {
-    // 216-colour cube
+    /* 216-colour cube */
     index -= 16;
 
     col->blue  = ramp6[index     % 6];
@@ -60,7 +60,7 @@ static bool lookup_colour_palette(const VTermState *state, long index, VTermColo
     return true;
   }
   else if(index >= 232 && index < 256) {
-    // 24 greyscales
+    /* 24 greyscales */
     index -= 232;
 
     col->blue  = ramp24[index];
@@ -76,7 +76,7 @@ static bool lookup_colour_palette(const VTermState *state, long index, VTermColo
 static int lookup_colour(const VTermState *state, int palette, const long args[], int argcount, VTermColor *col, int *index)
 {
   switch(palette) {
-  case 2: // RGB mode - 3 args contain colour values directly
+  case 2: /* RGB mode - 3 args contain colour values directly */
     if(argcount < 3)
       return argcount;
 
@@ -86,7 +86,7 @@ static int lookup_colour(const VTermState *state, int palette, const long args[]
 
     return 3;
 
-  case 5: // XTerm 256-colour mode
+  case 5: /* XTerm 256-colour mode */
     if(index)
       *index = CSI_ARG_OR(args[0], -1);
 
@@ -100,7 +100,7 @@ static int lookup_colour(const VTermState *state, int palette, const long args[]
   }
 }
 
-// Some conveniences
+/* Some conveniences */
 
 static void setpenattr(VTermState *state, VTermAttr attr, VTermValueType type, VTermValue *val)
 {
@@ -144,7 +144,7 @@ static void set_pen_col_ansi(VTermState *state, VTermAttr attr, long col)
 
 INTERNAL void vterm_state_newpen(VTermState *state)
 {
-  // 90% grey so that pure white is brighter
+  /* 90% grey so that pure white is brighter */
   state->default_fg.red = state->default_fg.green = state->default_fg.blue = 240;
   state->default_bg.red = state->default_bg.green = state->default_bg.blue = 0;
 
@@ -218,98 +218,98 @@ void vterm_state_set_bold_highbright(VTermState *state, int bold_is_highbright)
 
 INTERNAL void vterm_state_setpen(VTermState *state, const long args[], int argcount)
 {
-  // SGR - ECMA-48 8.3.117
+  /* SGR - ECMA-48 8.3.117 */
 
   int argi = 0;
   int value;
 
   while(argi < argcount) {
-    // This logic is easier to do 'done' backwards; set it true, and make it
-    // false again in the 'default' case
+    /* This logic is easier to do 'done' backwards; set it true, and make it
+     * false again in the 'default' case */
     int done = 1;
 
     long arg;
     switch(arg = CSI_ARG(args[argi])) {
     case CSI_ARG_MISSING:
-    case 0: // Reset
+    case 0: /* Reset */
       vterm_state_resetpen(state);
       break;
 
-    case 1: // Bold on
+    case 1: /* Bold on */
       state->pen.bold = 1;
       setpenattr_bool(state, VTERM_ATTR_BOLD, 1);
       if(state->fg_index > -1 && state->fg_index < 8 && state->bold_is_highbright)
         set_pen_col_ansi(state, VTERM_ATTR_FOREGROUND, state->fg_index + (state->pen.bold ? 8 : 0));
       break;
 
-    case 3: // Italic on
+    case 3: /* Italic on */
       state->pen.italic = 1;
       setpenattr_bool(state, VTERM_ATTR_ITALIC, 1);
       break;
 
-    case 4: // Underline single
+    case 4: /* Underline single */
       state->pen.underline = 1;
       setpenattr_int(state, VTERM_ATTR_UNDERLINE, 1);
       break;
 
-    case 5: // Blink
+    case 5: /* Blink */
       state->pen.blink = 1;
       setpenattr_bool(state, VTERM_ATTR_BLINK, 1);
       break;
 
-    case 7: // Reverse on
+    case 7: /* Reverse on */
       state->pen.reverse = 1;
       setpenattr_bool(state, VTERM_ATTR_REVERSE, 1);
       break;
 
-    case 9: // Strikethrough on
+    case 9: /* Strikethrough on */
       state->pen.strike = 1;
       setpenattr_bool(state, VTERM_ATTR_STRIKE, 1);
       break;
 
     case 10: case 11: case 12: case 13: case 14:
-    case 15: case 16: case 17: case 18: case 19: // Select font
+    case 15: case 16: case 17: case 18: case 19: /* Select font */
       state->pen.font = CSI_ARG(args[argi]) - 10;
       setpenattr_int(state, VTERM_ATTR_FONT, state->pen.font);
       break;
 
-    case 21: // Underline double
+    case 21: /* Underline double */
       state->pen.underline = 2;
       setpenattr_int(state, VTERM_ATTR_UNDERLINE, 2);
       break;
 
-    case 22: // Bold off
+    case 22: /* Bold off */
       state->pen.bold = 0;
       setpenattr_bool(state, VTERM_ATTR_BOLD, 0);
       break;
 
-    case 23: // Italic and Gothic (currently unsupported) off
+    case 23: /* Italic and Gothic (currently unsupported) off */
       state->pen.italic = 0;
       setpenattr_bool(state, VTERM_ATTR_ITALIC, 0);
       break;
 
-    case 24: // Underline off
+    case 24: /* Underline off */
       state->pen.underline = 0;
       setpenattr_int(state, VTERM_ATTR_UNDERLINE, 0);
       break;
 
-    case 25: // Blink off
+    case 25: /* Blink off */
       state->pen.blink = 0;
       setpenattr_bool(state, VTERM_ATTR_BLINK, 0);
       break;
 
-    case 27: // Reverse off
+    case 27: /* Reverse off */
       state->pen.reverse = 0;
       setpenattr_bool(state, VTERM_ATTR_REVERSE, 0);
       break;
 
-    case 29: // Strikethrough off
+    case 29: /* Strikethrough off */
       state->pen.strike = 0;
       setpenattr_bool(state, VTERM_ATTR_STRIKE, 0);
       break;
 
     case 30: case 31: case 32: case 33:
-    case 34: case 35: case 36: case 37: // Foreground colour palette
+    case 34: case 35: case 36: case 37: /* Foreground colour palette */
       value = CSI_ARG(args[argi]) - 30;
       state->fg_index = value;
       if(state->pen.bold && state->bold_is_highbright)
@@ -317,7 +317,7 @@ INTERNAL void vterm_state_setpen(VTermState *state, const long args[], int argco
       set_pen_col_ansi(state, VTERM_ATTR_FOREGROUND, value);
       break;
 
-    case 38: // Foreground colour alternative palette
+    case 38: /* Foreground colour alternative palette */
       state->fg_index = -1;
       if(argcount - argi < 1)
         return;
@@ -325,20 +325,20 @@ INTERNAL void vterm_state_setpen(VTermState *state, const long args[], int argco
       setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->pen.fg);
       break;
 
-    case 39: // Foreground colour default
+    case 39: /* Foreground colour default */
       state->fg_index = -1;
       state->pen.fg = state->default_fg;
       setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->pen.fg);
       break;
 
     case 40: case 41: case 42: case 43:
-    case 44: case 45: case 46: case 47: // Background colour palette
+    case 44: case 45: case 46: case 47: /* Background colour palette */
       value = CSI_ARG(args[argi]) - 40;
       state->bg_index = value;
       set_pen_col_ansi(state, VTERM_ATTR_BACKGROUND, value);
       break;
 
-    case 48: // Background colour alternative palette
+    case 48: /* Background colour alternative palette */
       state->bg_index = -1;
       if(argcount - argi < 1)
         return;
@@ -346,21 +346,21 @@ INTERNAL void vterm_state_setpen(VTermState *state, const long args[], int argco
       setpenattr_col(state, VTERM_ATTR_BACKGROUND, state->pen.bg);
       break;
 
-    case 49: // Default background
+    case 49: /* Default background */
       state->bg_index = -1;
       state->pen.bg = state->default_bg;
       setpenattr_col(state, VTERM_ATTR_BACKGROUND, state->pen.bg);
       break;
 
     case 90: case 91: case 92: case 93:
-    case 94: case 95: case 96: case 97: // Foreground colour high-intensity palette
+    case 94: case 95: case 96: case 97: /* Foreground colour high-intensity palette */
       value = CSI_ARG(args[argi]) - 90 + 8;
       state->fg_index = value;
       set_pen_col_ansi(state, VTERM_ATTR_FOREGROUND, value);
       break;
 
     case 100: case 101: case 102: case 103:
-    case 104: case 105: case 106: case 107: // Background colour high-intensity palette
+    case 104: case 105: case 106: case 107: /* Background colour high-intensity palette */
       value = CSI_ARG(args[argi]) - 100 + 8;
       state->bg_index = value;
       set_pen_col_ansi(state, VTERM_ATTR_BACKGROUND, value);
@@ -416,7 +416,7 @@ INTERNAL int vterm_state_getpen(VTermState *state, long args[], int argcount)
     args[argi++] = state->fg_index;
   }
   else if(state->fg_index == -1) {
-    // Send palette 2 if the actual FG colour is not default
+    /* Send palette 2 if the actual FG colour is not default */
     if(state->pen.fg.red   != state->default_fg.red   ||
        state->pen.fg.green != state->default_fg.green ||
        state->pen.fg.blue  != state->default_fg.blue  ) {
@@ -438,7 +438,7 @@ INTERNAL int vterm_state_getpen(VTermState *state, long args[], int argcount)
     args[argi++] = state->bg_index;
   }
   else if(state->bg_index == -1) {
-    // Send palette 2 if the actual BG colour is not default
+    /* Send palette 2 if the actual BG colour is not default */
     if(state->pen.bg.red   != state->default_bg.red   ||
        state->pen.bg.green != state->default_bg.green ||
        state->pen.bg.blue  != state->default_bg.blue  ) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -114,17 +114,17 @@ static void damagerect(VTermScreen *screen, VTermRect rect)
     /* Emit damage longer than one row. Try to merge with existing damage in
      * the same row */
     if(rect.end_row > rect.start_row + 1) {
-      // Bigger than 1 line - flush existing, emit this
+      /* Bigger than 1 line - flush existing, emit this */
       vterm_screen_flush_damage(screen);
       emit = rect;
     }
     else if(screen->damaged.start_row == -1) {
-      // None stored yet
+      /* None stored yet */
       screen->damaged = rect;
       return;
     }
     else if(rect.start_row == screen->damaged.start_row) {
-      // Merge with the stored line
+      /* Merge with the stored line */
       if(screen->damaged.start_col > rect.start_col)
         screen->damaged.start_col = rect.start_col;
       if(screen->damaged.end_col < rect.end_col)
@@ -132,7 +132,7 @@ static void damagerect(VTermScreen *screen, VTermRect rect)
       return;
     }
     else {
-      // Emit the currently stored line, store a new one
+      /* Emit the currently stored line, store a new one */
       emit = screen->damaged;
       screen->damaged = rect;
     }
@@ -209,9 +209,9 @@ static int moverect_internal(VTermRect dest, VTermRect src, void *user)
   VTermScreen *screen = user;
 
   if(screen->callbacks && screen->callbacks->sb_pushline &&
-     dest.start_row == 0 && dest.start_col == 0 &&  // starts top-left corner
-     dest.end_col == screen->cols &&                // full width
-     screen->buffer == screen->buffers[0]) {        // not altscreen
+     dest.start_row == 0 && dest.start_col == 0 &&  /* starts top-left corner */
+     dest.end_col == screen->cols &&                /* full width */
+     screen->buffer == screen->buffers[0]) {        /* not altscreen */
     VTermPos pos;
     for(pos.row = 0; pos.row < src.start_row; pos.row++) {
       for(pos.col = 0; pos.col < screen->cols; pos.col++)
@@ -250,7 +250,7 @@ static int moverect_user(VTermRect dest, VTermRect src, void *user)
 
   if(screen->callbacks && screen->callbacks->moverect) {
     if(screen->damage_merge != VTERM_DAMAGE_SCROLL)
-      // Avoid an infinite loop
+      /* Avoid an infinite loop */
       vterm_screen_flush_damage(screen);
 
     if((*screen->callbacks->moverect)(dest, src, screen->cbdata))
@@ -484,11 +484,11 @@ static int resize(int new_rows, int new_cols, VTermPos *delta, void *user)
   int old_cols = screen->cols;
 
   if(!is_altscreen && new_rows < old_rows) {
-    // Fewer rows - determine if we're going to scroll at all, and if so, push
-    // those lines to scrollback
+    /* Fewer rows - determine if we're going to scroll at all, and if so, push
+     * those lines to scrollback */
     VTermPos pos = { 0, 0 };
     VTermPos cursor = screen->state->pos;
-    // Find the first blank row after the cursor.
+    /* Find the first blank row after the cursor. */
     for(pos.row = old_rows - 1; pos.row >= new_rows; pos.row--)
       if(!vterm_screen_is_eol(screen, pos) || cursor.row == pos.row)
         break;
@@ -698,10 +698,10 @@ static size_t _get_chars(const VTermScreen *screen, const int utf8, void *buffer
       ScreenCell *cell = getcell(screen, row, col);
 
       if(cell->chars[0] == 0)
-        // Erased cell, might need a space
+        /* Erased cell, might need a space */
         padding++;
       else if(cell->chars[0] == (uint32_t)-1)
-        // Gap behind a double-width char, do nothing
+        /* Gap behind a double-width char, do nothing */
         ;
       else {
         while(padding) {
@@ -906,7 +906,7 @@ int vterm_screen_get_attrs_extent(const VTermScreen *screen, VTermRect *extent, 
 {
   ScreenCell *target = getcell(screen, pos.row, pos.col);
 
-  // TODO: bounds check
+  /* TODO: bounds check */
   extent->start_row = pos.row;
   extent->end_row   = pos.row + 1;
 

--- a/src/state.c
+++ b/src/state.c
@@ -98,7 +98,7 @@ static void scroll(VTermState *state, VTermRect rect, int downward, int rightwar
   else if(rightward < -cols)
     rightward = -cols;
 
-  // Update lineinfo if full line
+  /* Update lineinfo if full line */
   if(rect.start_col == 0 && rect.end_col == state->cols && rightward == 0) {
     int height = rect.end_row - rect.start_row - abs(downward);
 
@@ -219,7 +219,7 @@ static void set_lineinfo(VTermState *state, int row, int force, int dwl, int dhl
     info.doublewidth = DWL_OFF;
   else if(dwl == DWL_ON)
     info.doublewidth = DWL_ON;
-  // else -1 to ignore
+  /* else -1 to ignore */
 
   if(dhl == DHL_OFF)
     info.doubleheight = DHL_OFF;
@@ -241,7 +241,7 @@ static int on_text(const char bytes[], size_t len, void *user)
 
   VTermPos oldpos = state->pos;
 
-  // We'll have at most len codepoints
+  /* We'll have at most len codepoints */
   uint32_t codepoints[len];
   int npoints = 0;
   size_t eaten = 0;
@@ -310,7 +310,7 @@ static int on_text(const char bytes[], size_t len, void *user)
   }
 
   for(; i < npoints; i++) {
-    // Try to find combining characters following this
+    /* Try to find combining characters following this */
     int glyph_starts = i;
     int glyph_ends;
     for(glyph_ends = i + 1; glyph_ends < npoints; glyph_ends++)
@@ -412,54 +412,54 @@ static int on_control(unsigned char control, void *user)
   VTermPos oldpos = state->pos;
 
   switch(control) {
-  case 0x07: // BEL - ECMA-48 8.3.3
+  case 0x07: /* BEL - ECMA-48 8.3.3 */
     if(state->callbacks && state->callbacks->bell)
       (*state->callbacks->bell)(state->cbdata);
     break;
 
-  case 0x08: // BS - ECMA-48 8.3.5
+  case 0x08: /* BS - ECMA-48 8.3.5 */
     if(state->pos.col > 0)
       state->pos.col--;
     break;
 
-  case 0x09: // HT - ECMA-48 8.3.60
+  case 0x09: /* HT - ECMA-48 8.3.60 */
     tab(state, 1, +1);
     break;
 
-  case 0x0a: // LF - ECMA-48 8.3.74
-  case 0x0b: // VT
-  case 0x0c: // FF
+  case 0x0a: /* LF - ECMA-48 8.3.74 */
+  case 0x0b: /* VT */
+  case 0x0c: /* FF */
     linefeed(state);
     if(state->mode.newline)
       state->pos.col = 0;
     break;
 
-  case 0x0d: // CR - ECMA-48 8.3.15
+  case 0x0d: /* CR - ECMA-48 8.3.15 */
     state->pos.col = 0;
     break;
 
-  case 0x0e: // LS1 - ECMA-48 8.3.76
+  case 0x0e: /* LS1 - ECMA-48 8.3.76 */
     state->gl_set = 1;
     break;
 
-  case 0x0f: // LS0 - ECMA-48 8.3.75
+  case 0x0f: /* LS0 - ECMA-48 8.3.75 */
     state->gl_set = 0;
     break;
 
-  case 0x84: // IND - DEPRECATED but implemented for completeness
+  case 0x84: /* IND - DEPRECATED but implemented for completeness */
     linefeed(state);
     break;
 
-  case 0x85: // NEL - ECMA-48 8.3.86
+  case 0x85: /* NEL - ECMA-48 8.3.86 */
     linefeed(state);
     state->pos.col = 0;
     break;
 
-  case 0x88: // HTS - ECMA-48 8.3.62
+  case 0x88: /* HTS - ECMA-48 8.3.62 */
     set_col_tabstop(state, state->pos.col);
     break;
 
-  case 0x8d: // RI - ECMA-48 8.3.104
+  case 0x8d: /* RI - ECMA-48 8.3.104 */
     if(state->pos.row == state->scrollregion_top) {
       VTermRect rect = {
         .start_row = state->scrollregion_top,
@@ -474,11 +474,11 @@ static int on_control(unsigned char control, void *user)
         state->pos.row--;
     break;
 
-  case 0x8e: // SS2 - ECMA-48 8.3.141
+  case 0x8e: /* SS2 - ECMA-48 8.3.141 */
     state->gsingle_set = 2;
     break;
 
-  case 0x8f: // SS3 - ECMA-48 8.3.142
+  case 0x8f: /* SS3 - ECMA-48 8.3.142 */
     state->gsingle_set = 3;
     break;
 
@@ -564,11 +564,11 @@ static int on_escape(const char *bytes, size_t len, void *user)
       return 0;
 
     switch(bytes[1]) {
-      case 'F': // S7C1T
+      case 'F': /* S7C1T */
         state->vt->mode.ctrl8bit = 0;
         break;
 
-      case 'G': // S8C1T
+      case 'G': /* S8C1T */
         state->vt->mode.ctrl8bit = 1;
         break;
 
@@ -582,31 +582,31 @@ static int on_escape(const char *bytes, size_t len, void *user)
       return 0;
 
     switch(bytes[1]) {
-      case '3': // DECDHL top
+      case '3': /* DECDHL top */
         if(state->mode.leftrightmargin)
           break;
         set_lineinfo(state, state->pos.row, NO_FORCE, DWL_ON, DHL_TOP);
         break;
 
-      case '4': // DECDHL bottom
+      case '4': /* DECDHL bottom */
         if(state->mode.leftrightmargin)
           break;
         set_lineinfo(state, state->pos.row, NO_FORCE, DWL_ON, DHL_BOTTOM);
         break;
 
-      case '5': // DECSWL
+      case '5': /* DECSWL */
         if(state->mode.leftrightmargin)
           break;
         set_lineinfo(state, state->pos.row, NO_FORCE, DWL_OFF, DHL_OFF);
         break;
 
-      case '6': // DECDWL
+      case '6': /* DECDWL */
         if(state->mode.leftrightmargin)
           break;
         set_lineinfo(state, state->pos.row, NO_FORCE, DWL_ON, DHL_OFF);
         break;
 
-      case '8': // DECALN
+      case '8': /* DECALN */
       {
         VTermPos pos;
         uint32_t E[] = { 'E', 0 };
@@ -621,7 +621,7 @@ static int on_escape(const char *bytes, size_t len, void *user)
     }
     return 2;
 
-  case '(': case ')': case '*': case '+': // SCS
+  case '(': case ')': case '*': case '+': /* SCS */
     if(len != 2)
       return 0;
 
@@ -639,26 +639,26 @@ static int on_escape(const char *bytes, size_t len, void *user)
 
     return 2;
 
-  case '7': // DECSC
+  case '7': /* DECSC */
     savecursor(state, 1);
     return 1;
 
-  case '8': // DECRC
+  case '8': /* DECRC */
     savecursor(state, 0);
     return 1;
 
-  case '<': // Ignored by VT100. Used in VT52 mode to switch up to VT100
+  case '<': /* Ignored by VT100. Used in VT52 mode to switch up to VT100 */
     return 1;
 
-  case '=': // DECKPAM
+  case '=': /* DECKPAM */
     state->mode.keypad = 1;
     return 1;
 
-  case '>': // DECKPNM
+  case '>': /* DECKPNM */
     state->mode.keypad = 0;
     return 1;
 
-  case 'c': // RIS - ECMA-48 8.3.105
+  case 'c': /* RIS - ECMA-48 8.3.105 */
   {
     VTermPos oldpos = state->pos;
     vterm_state_reset(state, 1);
@@ -667,23 +667,23 @@ static int on_escape(const char *bytes, size_t len, void *user)
     return 1;
   }
 
-  case 'n': // LS2 - ECMA-48 8.3.78
+  case 'n': /* LS2 - ECMA-48 8.3.78 */
     state->gl_set = 2;
     return 1;
 
-  case 'o': // LS3 - ECMA-48 8.3.80
+  case 'o': /* LS3 - ECMA-48 8.3.80 */
     state->gl_set = 3;
     return 1;
 
-  case '~': // LS1R - ECMA-48 8.3.77
+  case '~': /* LS1R - ECMA-48 8.3.77 */
     state->gr_set = 1;
     return 1;
 
-  case '}': // LS2R - ECMA-48 8.3.79
+  case '}': /* LS2R - ECMA-48 8.3.79 */
     state->gr_set = 2;
     return 1;
 
-  case '|': // LS3R - ECMA-48 8.3.81
+  case '|': /* LS3R - ECMA-48 8.3.81 */
     state->gr_set = 3;
     return 1;
 
@@ -695,11 +695,11 @@ static int on_escape(const char *bytes, size_t len, void *user)
 static void set_mode(VTermState *state, int num, int val)
 {
   switch(num) {
-  case 4: // IRM - ECMA-48 7.2.10
+  case 4: /* IRM - ECMA-48 7.2.10 */
     state->mode.insert = val;
     break;
 
-  case 20: // LNM - ANSI X3.4-1977
+  case 20: /* LNM - ANSI X3.4-1977 */
     state->mode.newline = val;
     break;
 
@@ -716,11 +716,11 @@ static void set_dec_mode(VTermState *state, int num, int val)
     state->mode.cursor = val;
     break;
 
-  case 5: // DECSCNM - screen mode
+  case 5: /* DECSCNM - screen mode */
     settermprop_bool(state, VTERM_PROP_REVERSE, val);
     break;
 
-  case 6: // DECOM - origin mode
+  case 6: /* DECOM - origin mode */
     {
       VTermPos oldpos = state->pos;
       state->mode.origin = val;
@@ -742,11 +742,11 @@ static void set_dec_mode(VTermState *state, int num, int val)
     settermprop_bool(state, VTERM_PROP_CURSORVISIBLE, val);
     break;
 
-  case 69: // DECVSSM - vertical split screen mode
-           // DECLRMM - left/right margin mode
+  case 69: /* DECVSSM - vertical split screen mode */
+           /* DECLRMM - left/right margin mode */
     state->mode.leftrightmargin = val;
     if(val) {
-      // Setting DECVSSM must clear doublewidth/doubleheight state of every line
+      /* Setting DECVSSM must clear doublewidth/doubleheight state of every line */
       for(int row = 0; row < state->rows; row++)
         set_lineinfo(state, row, FORCE, DWL_OFF, DHL_OFF);
     }
@@ -886,7 +886,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
   int intermed_byte = 0;
 
   if(leader && leader[0]) {
-    if(leader[1]) // longer than 1 char
+    if(leader[1]) /* longer than 1 char */
       return 0;
 
     switch(leader[0]) {
@@ -900,7 +900,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
   }
 
   if(intermed && intermed[0]) {
-    if(intermed[1]) // longer than 1 char
+    if(intermed[1]) /* longer than 1 char */
       return 0;
 
     switch(intermed[0]) {
@@ -917,7 +917,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
   VTermPos oldpos = state->pos;
 
-  // Some temporaries for later code
+  /* Some temporaries for later code */
   int count, val;
   int row, col;
   VTermRect rect;
@@ -930,7 +930,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 #define INTERMED(i,b) ((i << 16) | b)
 
   switch(intermed_byte << 16 | leader_byte << 8 | command) {
-  case 0x40: // ICH - ECMA-48 8.3.64
+  case 0x40: /* ICH - ECMA-48 8.3.64 */
     count = CSI_ARG_COUNT(args[0]);
 
     if(!is_cursor_in_scrollregion(state))
@@ -948,54 +948,54 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x41: // CUU - ECMA-48 8.3.22
+  case 0x41: /* CUU - ECMA-48 8.3.22 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.row -= count;
     state->at_phantom = 0;
     break;
 
-  case 0x42: // CUD - ECMA-48 8.3.19
+  case 0x42: /* CUD - ECMA-48 8.3.19 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.row += count;
     state->at_phantom = 0;
     break;
 
-  case 0x43: // CUF - ECMA-48 8.3.20
+  case 0x43: /* CUF - ECMA-48 8.3.20 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.col += count;
     state->at_phantom = 0;
     break;
 
-  case 0x44: // CUB - ECMA-48 8.3.18
+  case 0x44: /* CUB - ECMA-48 8.3.18 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.col -= count;
     state->at_phantom = 0;
     break;
 
-  case 0x45: // CNL - ECMA-48 8.3.12
+  case 0x45: /* CNL - ECMA-48 8.3.12 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.col = 0;
     state->pos.row += count;
     state->at_phantom = 0;
     break;
 
-  case 0x46: // CPL - ECMA-48 8.3.13
+  case 0x46: /* CPL - ECMA-48 8.3.13 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.col = 0;
     state->pos.row -= count;
     state->at_phantom = 0;
     break;
 
-  case 0x47: // CHA - ECMA-48 8.3.9
+  case 0x47: /* CHA - ECMA-48 8.3.9 */
     val = CSI_ARG_OR(args[0], 1);
     state->pos.col = val-1;
     state->at_phantom = 0;
     break;
 
-  case 0x48: // CUP - ECMA-48 8.3.21
+  case 0x48: /* CUP - ECMA-48 8.3.21 */
     row = CSI_ARG_OR(args[0], 1);
     col = argcount < 2 || CSI_ARG_IS_MISSING(args[1]) ? 1 : CSI_ARG(args[1]);
-    // zero-based
+    /* zero-based */
     state->pos.row = row-1;
     state->pos.col = col-1;
     if(state->mode.origin) {
@@ -1005,13 +1005,13 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     state->at_phantom = 0;
     break;
 
-  case 0x49: // CHT - ECMA-48 8.3.10
+  case 0x49: /* CHT - ECMA-48 8.3.10 */
     count = CSI_ARG_COUNT(args[0]);
     tab(state, count, +1);
     break;
 
-  case 0x4a: // ED - ECMA-48 8.3.39
-  case LEADER('?', 0x4a): // DECSED - Selective Erase in Display
+  case 0x4a: /* ED - ECMA-48 8.3.39 */
+  case LEADER('?', 0x4a): /* DECSED - Selective Erase in Display */
     selective = (leader_byte == '?');
     switch(CSI_ARG(args[0])) {
     case CSI_ARG_MISSING:
@@ -1053,8 +1053,8 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     }
     break;
 
-  case 0x4b: // EL - ECMA-48 8.3.41
-  case LEADER('?', 0x4b): // DECSEL - Selective Erase in Line
+  case 0x4b: /* EL - ECMA-48 8.3.41 */
+  case LEADER('?', 0x4b): /* DECSEL - Selective Erase in Line */
     selective = (leader_byte == '?');
     rect.start_row = state->pos.row;
     rect.end_row   = state->pos.row + 1;
@@ -1076,7 +1076,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x4c: // IL - ECMA-48 8.3.67
+  case 0x4c: /* IL - ECMA-48 8.3.67 */
     count = CSI_ARG_COUNT(args[0]);
 
     if(!is_cursor_in_scrollregion(state))
@@ -1091,7 +1091,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x4d: // DL - ECMA-48 8.3.32
+  case 0x4d: /* DL - ECMA-48 8.3.32 */
     count = CSI_ARG_COUNT(args[0]);
 
     if(!is_cursor_in_scrollregion(state))
@@ -1106,7 +1106,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x50: // DCH - ECMA-48 8.3.26
+  case 0x50: /* DCH - ECMA-48 8.3.26 */
     count = CSI_ARG_COUNT(args[0]);
 
     if(!is_cursor_in_scrollregion(state))
@@ -1124,7 +1124,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x53: // SU - ECMA-48 8.3.147
+  case 0x53: /* SU - ECMA-48 8.3.147 */
     count = CSI_ARG_COUNT(args[0]);
 
     rect.start_row = state->scrollregion_top;
@@ -1136,7 +1136,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x54: // SD - ECMA-48 8.3.113
+  case 0x54: /* SD - ECMA-48 8.3.113 */
     count = CSI_ARG_COUNT(args[0]);
 
     rect.start_row = state->scrollregion_top;
@@ -1148,7 +1148,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x58: // ECH - ECMA-48 8.3.38
+  case 0x58: /* ECH - ECMA-48 8.3.38 */
     count = CSI_ARG_COUNT(args[0]);
 
     rect.start_row = state->pos.row;
@@ -1160,35 +1160,35 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     erase(state, rect, 0);
     break;
 
-  case 0x5a: // CBT - ECMA-48 8.3.7
+  case 0x5a: /* CBT - ECMA-48 8.3.7 */
     count = CSI_ARG_COUNT(args[0]);
     tab(state, count, -1);
     break;
 
-  case 0x60: // HPA - ECMA-48 8.3.57
+  case 0x60: /* HPA - ECMA-48 8.3.57 */
     col = CSI_ARG_OR(args[0], 1);
     state->pos.col = col-1;
     state->at_phantom = 0;
     break;
 
-  case 0x61: // HPR - ECMA-48 8.3.59
+  case 0x61: /* HPR - ECMA-48 8.3.59 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.col += count;
     state->at_phantom = 0;
     break;
 
-  case 0x63: // DA - ECMA-48 8.3.24
+  case 0x63: /* DA - ECMA-48 8.3.24 */
     val = CSI_ARG_OR(args[0], 0);
     if(val == 0)
-      // DEC VT100 response
+      /* DEC VT100 response */
       vterm_push_output_sprintf_ctrl(state->vt, C1_CSI, "?1;2c");
     break;
 
-  case LEADER('>', 0x63): // DEC secondary Device Attributes
+  case LEADER('>', 0x63): /* DEC secondary Device Attributes */
     vterm_push_output_sprintf_ctrl(state->vt, C1_CSI, ">%d;%d;%dc", 0, 100, 0);
     break;
 
-  case 0x64: // VPA - ECMA-48 8.3.158
+  case 0x64: /* VPA - ECMA-48 8.3.158 */
     row = CSI_ARG_OR(args[0], 1);
     state->pos.row = row-1;
     if(state->mode.origin)
@@ -1196,16 +1196,16 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     state->at_phantom = 0;
     break;
 
-  case 0x65: // VPR - ECMA-48 8.3.160
+  case 0x65: /* VPR - ECMA-48 8.3.160 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.row += count;
     state->at_phantom = 0;
     break;
 
-  case 0x66: // HVP - ECMA-48 8.3.63
+  case 0x66: /* HVP - ECMA-48 8.3.63 */
     row = CSI_ARG_OR(args[0], 1);
     col = argcount < 2 || CSI_ARG_IS_MISSING(args[1]) ? 1 : CSI_ARG(args[1]);
-    // zero-based
+    /* zero-based */
     state->pos.row = row-1;
     state->pos.col = col-1;
     if(state->mode.origin) {
@@ -1215,7 +1215,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     state->at_phantom = 0;
     break;
 
-  case 0x67: // TBC - ECMA-48 8.3.154
+  case 0x67: /* TBC - ECMA-48 8.3.154 */
     val = CSI_ARG_OR(args[0], 0);
 
     switch(val) {
@@ -1237,44 +1237,44 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     }
     break;
 
-  case 0x68: // SM - ECMA-48 8.3.125
+  case 0x68: /* SM - ECMA-48 8.3.125 */
     if(!CSI_ARG_IS_MISSING(args[0]))
       set_mode(state, CSI_ARG(args[0]), 1);
     break;
 
-  case LEADER('?', 0x68): // DEC private mode set
+  case LEADER('?', 0x68): /* DEC private mode set */
     if(!CSI_ARG_IS_MISSING(args[0]))
       set_dec_mode(state, CSI_ARG(args[0]), 1);
     break;
 
-  case 0x6a: // HPB - ECMA-48 8.3.58
+  case 0x6a: /* HPB - ECMA-48 8.3.58 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.col -= count;
     state->at_phantom = 0;
     break;
 
-  case 0x6b: // VPB - ECMA-48 8.3.159
+  case 0x6b: /* VPB - ECMA-48 8.3.159 */
     count = CSI_ARG_COUNT(args[0]);
     state->pos.row -= count;
     state->at_phantom = 0;
     break;
 
-  case 0x6c: // RM - ECMA-48 8.3.106
+  case 0x6c: /* RM - ECMA-48 8.3.106 */
     if(!CSI_ARG_IS_MISSING(args[0]))
       set_mode(state, CSI_ARG(args[0]), 0);
     break;
 
-  case LEADER('?', 0x6c): // DEC private mode reset
+  case LEADER('?', 0x6c): /* DEC private mode reset */
     if(!CSI_ARG_IS_MISSING(args[0]))
       set_dec_mode(state, CSI_ARG(args[0]), 0);
     break;
 
-  case 0x6d: // SGR - ECMA-48 8.3.117
+  case 0x6d: /* SGR - ECMA-48 8.3.117 */
     vterm_state_setpen(state, args, argcount);
     break;
 
-  case 0x6e: // DSR - ECMA-48 8.3.35
-  case LEADER('?', 0x6e): // DECDSR
+  case 0x6e: /* DSR - ECMA-48 8.3.35 */
+  case LEADER('?', 0x6e): /* DECDSR */
     val = CSI_ARG_OR(args[0], 0);
 
     {
@@ -1282,12 +1282,12 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
       switch(val) {
       case 0: case 1: case 2: case 3: case 4:
-        // ignore - these are replies
+        /* ignore - these are replies */
         break;
       case 5:
         vterm_push_output_sprintf_ctrl(state->vt, C1_CSI, "%s0n", qmark);
         break;
-      case 6: // CPR - cursor position report
+      case 6: /* CPR - cursor position report */
         vterm_push_output_sprintf_ctrl(state->vt, C1_CSI, "%s%d;%dR", qmark, state->pos.row + 1, state->pos.col + 1);
         break;
       }
@@ -1295,7 +1295,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     break;
 
 
-  case LEADER('!', 0x70): // DECSTR - DEC soft terminal reset
+  case LEADER('!', 0x70): /* DECSTR - DEC soft terminal reset */
     vterm_state_reset(state, 0);
     break;
 
@@ -1303,7 +1303,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     request_dec_mode(state, CSI_ARG(args[0]));
     break;
 
-  case INTERMED(' ', 0x71): // DECSCUSR - DEC set cursor shape
+  case INTERMED(' ', 0x71): /* DECSCUSR - DEC set cursor shape */
     val = CSI_ARG_OR(args[0], 1);
 
     switch(val) {
@@ -1335,7 +1335,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case INTERMED('"', 0x71): // DECSCA - DEC select character protection attribute
+  case INTERMED('"', 0x71): /* DECSCA - DEC select character protection attribute */
     val = CSI_ARG_OR(args[0], 0);
 
     switch(val) {
@@ -1349,7 +1349,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case 0x72: // DECSTBM - DEC custom
+  case 0x72: /* DECSTBM - DEC custom */
     state->scrollregion_top = CSI_ARG_OR(args[0], 1) - 1;
     state->scrollregion_bottom = argcount < 2 || CSI_ARG_IS_MISSING(args[1]) ? -1 : CSI_ARG(args[1]);
     LBOUND(state->scrollregion_top, 0);
@@ -1361,15 +1361,15 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
       UBOUND(state->scrollregion_bottom, state->rows);
 
     if(SCROLLREGION_BOTTOM(state) <= state->scrollregion_top) {
-      // Invalid
+      /* Invalid */
       state->scrollregion_top    = 0;
       state->scrollregion_bottom = -1;
     }
 
     break;
 
-  case 0x73: // DECSLRM - DEC custom
-    // Always allow setting these margins, just they won't take effect without DECVSSM
+  case 0x73: /* DECSLRM - DEC custom */
+    /* Always allow setting these margins, just they won't take effect without DECVSSM */
     state->scrollregion_left = CSI_ARG_OR(args[0], 1) - 1;
     state->scrollregion_right = argcount < 2 || CSI_ARG_IS_MISSING(args[1]) ? -1 : CSI_ARG(args[1]);
     LBOUND(state->scrollregion_left, 0);
@@ -1382,14 +1382,14 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     if(state->scrollregion_right > -1 &&
        state->scrollregion_right <= state->scrollregion_left) {
-      // Invalid
+      /* Invalid */
       state->scrollregion_left  = 0;
       state->scrollregion_right = -1;
     }
 
     break;
 
-  case INTERMED('\'', 0x7D): // DECIC
+  case INTERMED('\'', 0x7D): /* DECIC */
     count = CSI_ARG_COUNT(args[0]);
 
     if(!is_cursor_in_scrollregion(state))
@@ -1404,7 +1404,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
 
     break;
 
-  case INTERMED('\'', 0x7E): // DECDC
+  case INTERMED('\'', 0x7E): /* DECDC */
     count = CSI_ARG_COUNT(args[0]);
 
     if(!is_cursor_in_scrollregion(state))
@@ -1497,7 +1497,7 @@ static void request_status_string(VTermState *state, const char *command, size_t
 {
   if(cmdlen == 1)
     switch(command[0]) {
-      case 'm': // Query SGR
+      case 'm': /* Query SGR */
         {
           long args[20];
           int argc = vterm_state_getpen(state, args, sizeof(args)/sizeof(args[0]));
@@ -1512,10 +1512,10 @@ static void request_status_string(VTermState *state, const char *command, size_t
           vterm_push_output_sprintf_ctrl(state->vt, C1_ST, "");
         }
         return;
-      case 'r': // Query DECSTBM
+      case 'r': /* Query DECSTBM */
         vterm_push_output_sprintf_dcs(state->vt, "1$r%d;%dr", state->scrollregion_top+1, SCROLLREGION_BOTTOM(state));
         return;
-      case 's': // Query DECSLRM
+      case 's': /* Query DECSLRM */
         vterm_push_output_sprintf_dcs(state->vt, "1$r%d;%ds", SCROLLREGION_LEFT(state)+1, SCROLLREGION_RIGHT(state));
         return;
     }
@@ -1720,7 +1720,7 @@ void vterm_state_reset(VTermState *state, int hard)
 
   state->protected_cell = 0;
 
-  // Initialise the props
+  /* Initialise the props */
   settermprop_bool(state, VTERM_PROP_CURSORVISIBLE, 1);
   settermprop_bool(state, VTERM_PROP_CURSORBLINK,   1);
   settermprop_int (state, VTERM_PROP_CURSORSHAPE,   VTERM_PROP_CURSORSHAPE_BLOCK);
@@ -1788,7 +1788,7 @@ int vterm_state_set_termprop(VTermState *state, VTermProp prop, VTermValue *val)
   switch(prop) {
   case VTERM_PROP_TITLE:
   case VTERM_PROP_ICONNAME:
-    // we don't store these, just transparently pass through
+    /* we don't store these, just transparently pass through */
     return 1;
   case VTERM_PROP_CURSORVISIBLE:
     state->mode.cursor_visible = val->boolean;

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1,10 +1,11 @@
 #include "vterm_internal.h"
 
-// ### The following from http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
-// With modifications:
-//   made functions static
-//   moved 'combining' table to file scope, so other functions can see it
-// ###################################################################
+/* ### The following from http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
+ * With modifications:
+ *   made functions static
+ *   moved 'combining' table to file scope, so other functions can see it
+ * ###################################################################
+ */
 
 /*
  * This is an implementation of wcwidth() and wcswidth() (defined in
@@ -316,8 +317,8 @@ static int mk_wcswidth_cjk(const uint32_t *pwcs, size_t n)
   return width;
 }
 
-// ################################
-// ### The rest added by Paul Evans
+/* ################################ */
+/* ### The rest added by Paul Evans */
 
 INTERNAL int vterm_unicode_width(uint32_t codepoint)
 {

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -17,7 +17,7 @@ static int fill_utf8(long codepoint, char *str)
 {
   int nbytes = utf8_seqlen(codepoint);
 
-  // This is easier done backwards
+  /* This is easier done backwards */
   int b = nbytes;
   while(b > 1) {
     b--;

--- a/src/vterm_internal.h
+++ b/src/vterm_internal.h
@@ -29,7 +29,7 @@ typedef struct VTermEncoding VTermEncoding;
 typedef struct {
   VTermEncoding *enc;
 
-  // This size should be increased if required by other stateful encodings
+  /* This size should be increased if required by other stateful encodings */
   char           data[4*sizeof(uint32_t)];
 } VTermEncodingInstance;
 
@@ -96,9 +96,9 @@ struct VTermState
 
   /* Last glyph output, for Unicode recombining purposes */
   uint32_t *combine_chars;
-  size_t combine_chars_size; // Number of ELEMENTS in the above
-  int combine_width; // The width of the glyph above
-  VTermPos combine_pos;   // Position before movement
+  size_t combine_chars_size; /* Number of ELEMENTS in the above */
+  int combine_width; /* The width of the glyph above */
+  VTermPos combine_pos;   /* Position before movement */
 
   struct {
     unsigned int keypad:1;
@@ -124,7 +124,7 @@ struct VTermState
 
   VTermColor default_fg;
   VTermColor default_bg;
-  VTermColor colors[16]; // Store the 8 ANSI and the 8 ANSI high-brights only
+  VTermColor colors[16]; /* Store the 8 ANSI and the 8 ANSI high-brights only */
 
   int fg_index;
   int bg_index;


### PR DESCRIPTION
Currently comments use a mix of // and /* */ styles.  This change turns them all into /* */ comments.
This allows for building with C90 standard compilers.