### PR TITLE
Setting the scrolling region restores the cursor to the home position

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -1412,6 +1412,14 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
       state->scrollregion_bottom = -1;
     }
 
+    // Setting the scrolling region restores the cursor to the home position
+    state->pos.row = 0;
+    state->pos.col = 0;
+    if(state->mode.origin) {
+      state->pos.row += state->scrollregion_top;
+      state->pos.col += SCROLLREGION_LEFT(state);
+    }
+
     break;
 
   case 0x73: // DECSLRM - DEC custom


### PR DESCRIPTION
This patch fixes the behavior of the DECSTBM command so that the cursor is moved to the home position when the scrolling region is set.  This is in line with the DEC documentation (https://vt100.net/docs/vt510-rm/DECSTBM.html) and some existing software depends on the cursor movement to be made.