### PR TITLE
Make libvterm compile on arm64 Macs

### DIFF
--- a/bin/vterm-ctrl.c
+++ b/bin/vterm-ctrl.c
@@ -1,4 +1,8 @@
-#define _XOPEN_SOURCE 500  /* strdup */
+#if defined(__APPLE__) && defined(__arm64__)
+  #define _XOPEN_SOURCE 600  /* strdup */
+#else
+  #define _XOPEN_SOURCE 500  /* strdup */
+#endif
 
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
I'm not sure whether this is the best way to do it. This patch is needed for neovim/neovim#12624.